### PR TITLE
[@types/apidoc] Missing `src` option

### DIFF
--- a/types/apidoc/apidoc-tests.ts
+++ b/types/apidoc/apidoc-tests.ts
@@ -1,50 +1,29 @@
 import { createDoc } from 'apidoc';
 
 const apidocOutput = createDoc({
+    excludeFilters: [''],
+    includeFilters: [''],
     src: '',
     dest: '',
     template: '',
     templateSingleFile: '',
-    debug: true,
-    single: true,
-    silent: true,
-    verbose: true,
-    simulate: true,
-    parse: true,
-    colorize: true,
-    markdown: true,
     config: '',
     apiprivate: true,
+    verbose: true,
+    single: true,
+    debug: true,
+    parse: true,
+    colorize: true,
+    filters: { aFilter: '' },
+    languages: { aLanguage: '' },
+    parsers: { aParser: '' },
+    workers: { aWorker: '' },
+    silent: true,
+    simulate: true,
+    markdown: true,
+    lineEnding: '',
     encoding: '',
-    excludeFilters: [],
-    includeFilters: [],
-    filters: {
-        api: {
-            postFilter: (parsedFiles, parsedFilenames) => { }
-        }
-    },
-    languages: {
-        default: {
-            docBlocksRegExp: /\/\*\*.*\*\//,
-            inlineRegExp: /\@/,
-        }
-    },
-    parsers: {
-        parse: (content, source, messagesg) => ({
-            name: '',
-            title: '',
-            description: '',
-        }),
-        path: '',
-        getGroup: () => '',
-        markdownFields: [],
-        markdownRemovePTags: [],
-    },
-    workers: {
-        work: {}
-    },
-    lineEnding: 'LF',
-    copyDefinitions: false,
+    copyDefinitions: true,
     filterBy: '',
 });
 

--- a/types/apidoc/apidoc-tests.ts
+++ b/types/apidoc/apidoc-tests.ts
@@ -1,6 +1,7 @@
 import { createDoc } from 'apidoc';
 
 const apidocOutput = createDoc({
+    src: '',
     dest: '',
     template: '',
     templateSingleFile: '',
@@ -42,7 +43,7 @@ const apidocOutput = createDoc({
     workers: {
         work: {}
     },
-    lineEnding: "LF",
+    lineEnding: 'LF',
     copyDefinitions: false,
     filterBy: '',
 });

--- a/types/apidoc/index.d.ts
+++ b/types/apidoc/index.d.ts
@@ -8,52 +8,32 @@ export interface ParsedFile {
     filename: string;
     extension: string;
     src: string;
-
     blocks: Array<{ global: any; local: any; }>;
 }
+
 export interface DocOptions {
-    dest?: string | string[];
-    template?: string;
-    templateSingleFile?: string;
-    debug?: boolean;
-    single?: boolean;
-    silent?: boolean;
-    verbose?: boolean;
-    simulate?: boolean;
-    parse?: boolean;
-    colorize?: boolean;
-    markdown?: boolean;
-    config?: string;
-    apiprivate?: boolean;
-    encoding?: string;
     excludeFilters?: string[];
     includeFilters?: string[];
-    filters?: {
-        [keys: string]: {
-            postFilter: (parsedFiles: ParsedFile[], parsedFilenames: string[]) => void
-        }
-    };
-    languages?: {
-        [language: string]: {
-            docBlocksRegExp: RegExp;
-            inlineRegExp: RegExp;
-        }
-    };
-    parsers?: {
-        parse: (content: string, source: string, messages: string) => {
-            name: string;
-            title: string;
-            description: string;
-        };
-        path: string;
-        getGroup?: () => string;
-        markdownFields?: string[];
-        markdownRemovePTags?: string[];
-    };
-    workers?: {
-        [keys: string]: any;
-    };
+    src?: string;
+    dest?: string;
+    template?: string;
+    templateSingleFile?: string;
+    config?: string;
+    apiprivate?: boolean;
+    verbose?: boolean;
+    single?: boolean;
+    debug?: boolean;
+    parse?: boolean;
+    colorize?: boolean;
+    filters?: Record<string, string>;
+    languages?: Record<string, string>;
+    parsers?: Record<string, string>;
+    workers?: Record<string, string>;
+    silent?: boolean;
+    simulate?: boolean;
+    markdown?: boolean;
     lineEnding?: string;
+    encoding?: string;
     copyDefinitions?: boolean;
     filterBy?: string | string[];
 }


### PR DESCRIPTION
Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `npm test`.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes:
 - Add `src` parameters: https://github.com/apidoc/apidoc/blob/master/bin/apidoc#L106
 - Fix invalid argument definitions: https://github.com/apidoc/apidoc-core/blob/568d40f7f41b705bf3a90798716648341a803964/lib/index.js#L42-L97
- [x] Include [tests for your changes](https://github.com/DefinitelyTyped/DefinitelyTyped#testing)

